### PR TITLE
[bugfix][android] Use an activity context whenever it is available

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNUportHDSignerModule.kt
+++ b/android/src/main/java/com/reactlibrary/RNUportHDSignerModule.kt
@@ -41,7 +41,7 @@ class RNUportHDSignerModule(reactContext: ReactApplicationContext)
     fun hasSeed(promise: Promise?) {
         promise!!
 
-        promise.resolve(UportHDSigner().hasSeed(reactApplicationContext))
+        promise.resolve(UportHDSigner().hasSeed(currentActivity ?: reactApplicationContext))
     }
 
     /**
@@ -61,7 +61,7 @@ class RNUportHDSignerModule(reactContext: ReactApplicationContext)
         val keyLevel: Level = keyLevelFromString(level ?: "")
 
         UportHDSigner().createHDSeed(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 keyLevel
         ) { err, address, pubKey ->
             if (err != null) {
@@ -77,7 +77,7 @@ class RNUportHDSignerModule(reactContext: ReactApplicationContext)
     @ReactMethod
     fun deleteSeed(label: String) {
         UportHDSigner().deleteSeed(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 label
         )
     }
@@ -107,7 +107,7 @@ class RNUportHDSignerModule(reactContext: ReactApplicationContext)
                 ?: return promise.reject(IllegalArgumentException("derivation path can't be null"))
 
         UportHDSigner().computeAddressForPath(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 rootAddr,
                 hdPath,
                 prompt ?: ""
@@ -141,7 +141,7 @@ class RNUportHDSignerModule(reactContext: ReactApplicationContext)
                 IllegalArgumentException("root address can't be null"))
 
         UportHDSigner().showHDSeed(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 rootAddr,
                 prompt ?: ""
         ) { err, phrase ->
@@ -177,7 +177,7 @@ class RNUportHDSignerModule(reactContext: ReactApplicationContext)
         seed!!
 
         UportHDSigner().importHDSeed(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 keyLevel,
                 seed
         ) { err, address, pubKey ->
@@ -351,7 +351,7 @@ class RNUportHDSignerModule(reactContext: ReactApplicationContext)
     fun listSeedAddresses(promise: Promise?) {
         promise!!
 
-        val addresses = UportHDSigner().allHDRoots(reactApplicationContext) 
+        val addresses = UportHDSigner().allHDRoots(currentActivity ?: reactApplicationContext)
         val ret = WritableNativeArray()
         addresses.forEach { ret.pushString(it) }
         promise.resolve(ret)

--- a/android/src/main/java/com/reactlibrary/RNUportSignerModule.kt
+++ b/android/src/main/java/com/reactlibrary/RNUportSignerModule.kt
@@ -29,17 +29,17 @@ open class RNUportSignerModule(reactContext: ReactApplicationContext)
 
     @ReactMethod
     fun hasSecureKeyguard(promise: Promise) {
-        UportSigner().hasSecuredKeyguard(reactApplicationContext) { promise.resolve(it) }
+        UportSigner().hasSecuredKeyguard(currentActivity ?: reactApplicationContext) { promise.resolve(it) }
     }
 
     @ReactMethod
     fun hasFingerprintHardware(promise: Promise) {
-        UportSigner().hasFingerprintHardware(reactApplicationContext) { promise.resolve(it) }
+        UportSigner().hasFingerprintHardware(currentActivity ?: reactApplicationContext) { promise.resolve(it) }
     }
 
     @ReactMethod
     fun hasSetupFingerprints(promise: Promise) {
-        UportSigner().hasSetupFingerprints(reactApplicationContext) { promise.resolve(it) }
+        UportSigner().hasSetupFingerprints(currentActivity ?: reactApplicationContext) { promise.resolve(it) }
     }
 
     @ReactMethod
@@ -70,7 +70,7 @@ open class RNUportSignerModule(reactContext: ReactApplicationContext)
         val keyLevel: Level = keyLevelFromString(level ?: "")
 
         UportSigner().createKey(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 keyLevel
         ) { err, address, pubKey ->
             if (err != null) {
@@ -106,7 +106,7 @@ open class RNUportSignerModule(reactContext: ReactApplicationContext)
         }
 
         UportSigner().saveKey(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 keyLevel,
                 privKeyBytes
         ) { err, address, pubKey ->
@@ -123,7 +123,7 @@ open class RNUportSignerModule(reactContext: ReactApplicationContext)
     @ReactMethod
     fun deleteKey(address: String) {
         UportSigner().deleteKey(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 address
         )
     }
@@ -188,7 +188,7 @@ open class RNUportSignerModule(reactContext: ReactApplicationContext)
         promise!!
 
         UportSigner().allAddresses(
-                reactApplicationContext
+                currentActivity ?: reactApplicationContext
         ) { addresses ->
             val ret = WritableNativeArray()
             addresses.forEach { ret.pushString(it) }
@@ -207,7 +207,7 @@ open class RNUportSignerModule(reactContext: ReactApplicationContext)
         val privKey = privateKey ?: return promise.reject(IllegalArgumentException(ERR_BLANK_KEY))
 
         UportSigner().storeEncryptedPayload(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 keyLevel,
                 asGenericLabel(pubKey),
                 privKey.toByteArray(Charsets.UTF_8)
@@ -259,7 +259,7 @@ open class RNUportSignerModule(reactContext: ReactApplicationContext)
         address!!
 
         UportSigner().storeEncryptedPayload(
-                reactApplicationContext,
+                currentActivity ?: reactApplicationContext,
                 keyLevel,
                 asSeedLabel(address),
                 seed.toByteArray()


### PR DESCRIPTION
### What's here
This fixes https://www.pivotaltracker.com/story/show/165862494
Using `prompt` for seed protection throws `E_ACTIVITY_NOT_FOUND` error on android when revealing the seed or deriving keys.

### Testing:
To test this, the [react-native-signer-demo](https://github.com/uport-project/react-native-signer-demo) can be used.

1. in the signer demo, for the HDSigner user flow change the seed create/import to `prompt` instead of `simple` and try to show seed. It will either crash or show a yellowbox with E_ACTIVITY_NOT_FOUND.
It may also crash or misbehave when deriving keys.
This reproduces the bug.
2. update the `package.json` of the demoapp to use `"react-native-uport-signer": "https://github.com/uport-project/react-native-uport-signer#bugfix/165862494-fix-activity-error-on-android",`
repeat the scenario from `1.` and validate that the HDSigner can be used both for signing and to reveal the seed and derive keys with fingerprint protection.