### PR TITLE
[bugfix][android] unsilence errors during JWT signing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,7 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 
-    api "com.github.uport-project.uport-android-sdk:signer:v0.4.2"
+    api "com.github.uport-project:uport-android-signer:0.3.1"
+    api "com.github.uport-project.kotlin-common:signer-common:0.1.1"
 }
   

--- a/android/src/main/java/com/reactlibrary/RNUportHDSignerModule.kt
+++ b/android/src/main/java/com/reactlibrary/RNUportHDSignerModule.kt
@@ -12,11 +12,11 @@ import com.uport.sdk.signer.UportHDSigner
 import com.uport.sdk.signer.UportSigner
 import com.uport.sdk.signer.UportSigner.Companion.ERR_BLANK_KEY
 import com.uport.sdk.signer.encryption.KeyProtection.Level
-import com.uport.sdk.signer.keyToBase64
 import org.kethereum.bip39.entropyToMnemonic
 import org.kethereum.bip39.model.MnemonicWords
 import org.kethereum.bip39.toKey
 import org.kethereum.bip39.wordlists.WORDLIST_ENGLISH
+import me.uport.sdk.signer.keyToBase64
 import java.util.*
 
 
@@ -279,7 +279,11 @@ class RNUportHDSignerModule(reactContext: ReactApplicationContext)
                 return@signJwtBundle promise.reject(err)
             }
             val map = WritableNativeMap()
-            val rec: Int = if (sigData.v > 1) { (sigData.v + 1) % 2 } else { sigData.v.toInt() }
+            val rec: Int = if (sigData.v > 1) {
+                (sigData.v + 1) % 2
+            } else {
+                sigData.v.toInt()
+            }
             map.putInt("v", rec)
             map.putString("r", sigData.r.keyToBase64())
             map.putString("s", sigData.s.keyToBase64())

--- a/android/src/main/java/com/reactlibrary/RNUportSignerModule.kt
+++ b/android/src/main/java/com/reactlibrary/RNUportSignerModule.kt
@@ -16,7 +16,7 @@ import com.uport.sdk.signer.UportSigner.Companion.ERR_ENCODING_ERROR
 import com.uport.sdk.signer.UportSigner.Companion.asGenericLabel
 import com.uport.sdk.signer.UportSigner.Companion.asSeedLabel
 import com.uport.sdk.signer.encryption.KeyProtection.Level
-import com.uport.sdk.signer.keyToBase64
+import me.uport.sdk.signer.keyToBase64
 
 /**
  * This module deals with creating, importing, and using private keys.


### PR DESCRIPTION
This fixes a situation where some errors would be swallowed up and not being reported during signing JWTs and some other key usage scenarios.

The promises would be resolved with blank signature instead of being rejected with the error.

Testing for this is done at the native android signer level. here it is just a version bump