### PR TITLE
[bugfix][android] compilation error - duplicate classes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
 
     api "com.github.uport-project:uport-android-signer:0.3.1"
-    api "com.github.uport-project.kotlin-common:signer-common:0.1.1"
+
+    testImplementation "junit:junit:4.12"
 }
   


### PR DESCRIPTION
This fixes #21

To reproduce the bug, follow these steps:

* `react-native init TestProject`
*  (using RN 0.59.8)
* ... install react-native-uport-signer@1.3.3 following installation steps from readme
* `react-native run-android`

To test the fix, point `package.json` to this branch