### PR TITLE
[android] bump uport-android-signer to 0.3.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
+        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.41"
     }
 }
 
@@ -39,10 +39,15 @@ repositories {
     }
 }
 
+//XXX: this is needed until https://github.com/komputing/KEthereum/issues/65 is fixed
+configurations.all {
+    exclude group: "com.github.walleth"
+}
+
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 
-    api "com.github.uport-project:uport-android-signer:0.3.1"
+    api "com.github.uport-project:uport-android-signer:0.3.2"
 
     testImplementation "junit:junit:4.12"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
this fixes #23 (IllegalStateException when using `prompt` without fingerprint)